### PR TITLE
Added Custom field to PdfMeta.

### DIFF
--- a/jsreport.Types/Request/PdfMeta.cs
+++ b/jsreport.Types/Request/PdfMeta.cs
@@ -12,5 +12,6 @@ namespace jsreport.Types
         public string Keywords { get; set; }
         public string Creator { get; set; }
         public string Producer { get; set; }
+        public Dictionary<string, string> Custom { get; set; }
     }
 }


### PR DESCRIPTION
Hi,

As promised here is the necessary changed to support adding custom meta data properties to PDFs from the C# client for the featured added in https://github.com/jsreport/jsreport/pull/981.

There will be an accompanying pull request for jsreport-dotnet-shared which handles the serialization of RenderRequests (https://github.com/jsreport/jsreport-dotnet-shared/pull/4).