### PR TITLE
Add more TargetFrameworks

### DIFF
--- a/jsreport.Types/jsreport.Types.csproj
+++ b/jsreport.Types/jsreport.Types.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;net45</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.6;netstandard2.0;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>3.9.4</Version>
+    <Version>3.9.5</Version>
     <Description>jsreport entities strong types used in .net sdk</Description>
     <Company>jsreport</Company>
     <Product>jsreport</Product>
@@ -17,8 +17,8 @@
     <RepositoryType>git</RepositoryType>
     <PackageReleaseNotes>Release notes are at https://github.com/jsreport/jsreport-dotnet-types/releases</PackageReleaseNotes>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AssemblyVersion>3.9.4.0</AssemblyVersion>
-    <FileVersion>3.9.4.0</FileVersion>
+    <AssemblyVersion>3.9.5.0</AssemblyVersion>
+    <FileVersion>3.9.5.0</FileVersion>
     <PackageIcon>icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>


### PR DESCRIPTION
Add modern TargetFramework to prevent outdated dependencies to flow in project.
![image](https://github.com/user-attachments/assets/b5acc35e-501a-4ba5-be69-0e2f0bd89795)
Most of those dependencies are useless in NetStandard 2.0 and later target framework.
It also start causing warning in Visual Studio 17.12.

After the PRs:
![image](https://github.com/user-attachments/assets/f3208f3e-c288-4368-9aca-03af7d5b71bf)